### PR TITLE
Various changes to 00 script

### DIFF
--- a/00_mastodon_test.sh
+++ b/00_mastodon_test.sh
@@ -24,8 +24,10 @@ echo ""
 echo "Installing system dependencies"
 brew install    rbenv ruby-build gnu-sed libidn libpq postgresql redis yarn ffmpeg imagemagick
 
-echo "Using rbenv to set ruby version to 3.2.1"
-rbenv global 3.2.1
+rbenv install 3.2.2
+
+echo "Using rbenv to set ruby version to 3.2.2"
+rbenv global 3.2.2
 
 echo "Git checckout, clean, and pull"
 git checkout .


### PR DESCRIPTION
These are some changes I needed to make to get 00 working on my personal computer. Have not yet tried on my work computer – but I'd like to.

Other things I needed to do that are not representable in this script:
I added the following to my `~/.bash_profile` and restarted my shell:
```
export PATH="$HOME/.rbenv/bin:$PATH"
eval "$(rbenv init -)"
eval "$(rbenv init - bash)"
```
